### PR TITLE
Update pets_controller_spec.rb

### DIFF
--- a/spec/controllers/pets_controller_spec.rb
+++ b/spec/controllers/pets_controller_spec.rb
@@ -70,7 +70,7 @@ describe "Pets Controller" do
     end
 
     it "can visit '/pets/:id/edit' " do 
-      get "/owners/#{@pet.id}/edit"
+      get "/pets/#{@pet.id}/edit"
       expect(last_response.status).to eq(200)
     end
 


### PR DESCRIPTION
can visit '/pets/:id/edit' test was testing route '/owners/#{@pet.id}/edit' but should be testing route '/pets/#{@pet.id}/edit'